### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,9 @@
 # .github/workflows/coverage.yml
 name: Run Tests & Upload Coverage
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/AitzazImtiaz/arsla-lang/security/code-scanning/2](https://github.com/AitzazImtiaz/arsla-lang/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only checks out code, installs dependencies, runs tests, and uploads coverage reports, it does not require write permissions. The minimal permissions required are `contents: read`, which allows the workflow to read repository contents.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. This ensures that the `GITHUB_TOKEN` used in the workflow has restricted access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
