### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/AitzazImtiaz/arsla-lang/security/code-scanning/1](https://github.com/AitzazImtiaz/arsla-lang/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to read the repository's contents (e.g., to install dependencies and analyze Python files), we will set `contents: read`. This ensures that the workflow has the minimum permissions required to function correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
